### PR TITLE
add CI workflow for mariadb+mysql

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,11 @@ jobs:
   smoke-test:
     name: Setup infrastructure
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # run test with the default, which is "mariadb", and the feature flag
+        # which will run mysql in a separate container
+        mysql-feature-flag: ["default (mariadb)", "mysql"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -36,11 +41,17 @@ jobs:
         env:
           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
           LOCALSTACK_VOLUME_DIR: ${{ github.workspace }}/ls_test
+          MYSQL_FEATURE_FLAG: ${{ matrix.mysql-feature-flag }}
         run: |
           mkdir ls_test
+          ls -la ls_test
           docker pull localstack/localstack-pro:latest
           # Start LocalStack in the background
-          DEBUG=1 RDS_MYSQL_DOCKER=1 localstack start -d
+          if [ "mysql" ==  ${MYSQL_FEATURE_FLAG} ]; then
+            DEBUG=1 RDS_MYSQL_DOCKER=1 localstack start -d
+          else
+            DEBUG=1 localstack start -d
+          fi
           # Wait 30 seconds for the LocalStack container to become ready before timing out
           echo "Waiting for LocalStack startup..."
           localstack wait -t 15
@@ -77,6 +88,6 @@ jobs:
             exit 1
           fi
       - name: Show Logs
-        if: failure()
+        if: always()
         run: |
           localstack logs


### PR DESCRIPTION
Currently mariadb is the default installation when the engine `mysql` is selected.
Adapt the workflow to run the test using the default (`mariadb`) and the real `mysql` engine, by setting the feature flag.

**Note**: Not sure what the original issue two weeks ago was (the deployment with mariadb failed with permission errors), but it did not came up again. There have been no changes in RDS, nor in the pipeline that would explain this behavior.

Printing the logs in the workflow to verify the correct DB was installed.